### PR TITLE
tissot: fix whatsapp camera lag

### DIFF
--- a/prop.mk
+++ b/prop.mk
@@ -8,5 +8,5 @@ ro.vendor.audio.sdk.fluencetype=fluence
 # Camera
 PRODUCT_PROPERTY_OVERRIDES += \
 vendor.camera.aux.packagelist=org.codeaurora.snapcam,com.android.camera,org.lineageos.snap \
-persist.camera.dual.camera=0
-
+persist.camera.dual.camera=0 \
+vendor.camera.hal1.packagelist=com.whatsapp


### PR DESCRIPTION
This can be useful for GCam users.
Huge thanks to @Dil3mm4 for helping me finding this.
Normally, camera.hal1.packagelist won't work. It should be vendor.camera.hal1.packagelist.